### PR TITLE
Port code to preCICE v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,9 +106,9 @@ cython_debug/
 
 # preCICE output
 **/*-events-summary.log
-**/*-events.json
 **/*-iterations.log
 **/*-convergence.log
+**/*.json
 
 # Simulation output
 *.xml

--- a/coupling/groundwater.py
+++ b/coupling/groundwater.py
@@ -4,7 +4,7 @@ import numpy as np
 import precice
 import ufl
 import xarray as xr
-from dune.fem.function import uflFunction
+from dune.fem.function import gridFunction
 from dune.fem.operator import galerkin as galerkin_operator
 from dune.fem.scheme import galerkin as galerkin_scheme
 from dune.fem.space import lagrange
@@ -38,7 +38,7 @@ class Groundwater:
         phi = ufl.TestFunction(self.space)
 
         # get x-values for plotting/visualization
-        x_func = uflFunction(gridView, name="x", order=1, ufl=x)
+        x_func = gridFunction(x, gridView, name="x", order=1)
         self.x_axis = self.space.interpolate(x_func).as_numpy
 
         if params.ic_type == InitialCondition.linear:

--- a/coupling/groundwater.py
+++ b/coupling/groundwater.py
@@ -160,16 +160,18 @@ def simulate_groundwater(params: Params):
 
         precice_dt = participant.get_max_time_step_size()
         dt = min(params.dt, precice_dt)
+        t = groundwater.scheme.model.time
+        read_data = participant.read_data(mesh_name, read_data_name, vertex_ids, t + dt)
+        groundwater.height.value = read_data[0]
 
-        groundwater.height.value = participant.read_data(mesh_name, read_data_name)
         groundwater.solve(dt)
-        participant.write_data(
-            mesh_name, write_data_name, vertex_ids, [groundwater.interface_flux]
-        )
+
+        write_data = [groundwater.interface_flux]
+        participant.write_data(mesh_name, write_data_name, vertex_ids, write_data)
 
         precice_dt = participant.advance(dt)
 
-        if participant.requires_writing_checkpoint():
+        if participant.requires_reading_checkpoint():
             groundwater.load_state()
         else:
             groundwater.end_time_step()

--- a/coupling/precice-config.xml.j2
+++ b/coupling/precice-config.xml.j2
@@ -2,57 +2,53 @@
 
 <precice-configuration>
 
-  <solver-interface dimensions="2">
+  <data:scalar name="Height"/>
+  <data:scalar name="Flux"/>
 
-    <data:scalar name="Height"/>
-    <data:scalar name="Flux"/>
+  <mesh name="GroundwaterMesh" dimensions="2">
+    <use-data name="Height"/>
+    <use-data name="Flux"/>
+  </mesh>
 
-    <mesh name="GroundwaterMesh">
-      <use-data name="Height"/>
-      <use-data name="Flux"/>
-    </mesh>
+  <mesh name="RiverMesh" dimensions="2">
+    <use-data name="Height"/>
+    <use-data name="Flux"/>
+  </mesh>
 
-    <mesh name="RiverMesh">
-      <use-data name="Height"/>
-      <use-data name="Flux"/>
-    </mesh>
+  <participant name="GroundwaterSolver">
+    <provide-mesh name="GroundwaterMesh"/>
+    <receive-mesh name="RiverMesh" from="RiverSolver"/>
+    <write-data name="Flux" mesh="GroundwaterMesh"/>
+    <read-data  name="Height" mesh="GroundwaterMesh"/>
+    <mapping:nearest-neighbor direction="write" from="GroundwaterMesh"
+                              to="RiverMesh" constraint="conservative"/>
+    <mapping:nearest-neighbor direction="read" from="RiverMesh"
+                              to="GroundwaterMesh" constraint="consistent"/>
+  </participant>
 
-    <participant name="GroundwaterSolver">
-      <use-mesh name="GroundwaterMesh" provide="yes"/>
-      <use-mesh name="RiverMesh" from="RiverSolver"/>
-      <write-data name="Flux" mesh="GroundwaterMesh"/>
-      <read-data  name="Height" mesh="GroundwaterMesh"/>
-      <mapping:nearest-neighbor direction="write" from="GroundwaterMesh"
-                                to="RiverMesh" constraint="conservative"/>
-      <mapping:nearest-neighbor direction="read" from="RiverMesh"
-                                to="GroundwaterMesh" constraint="consistent"/>
-    </participant>
+  <participant name="RiverSolver">
+    <provide-mesh name="RiverMesh"/>
+    <write-data name="Height" mesh="RiverMesh"/>
+    <read-data  name="Flux" mesh="RiverMesh"/>
+  </participant>
 
-    <participant name="RiverSolver">
-      <use-mesh name="RiverMesh" provide="yes"/>
-      <write-data name="Height" mesh="RiverMesh"/>
-      <read-data  name="Flux" mesh="RiverMesh"/>
-    </participant>
+  <m2n:sockets acceptor="GroundwaterSolver" connector="RiverSolver"/>
 
-    <m2n:sockets from="GroundwaterSolver" to="RiverSolver"/>
-
-    <coupling-scheme:{{coupling_scheme}}>
-      <participants first="GroundwaterSolver" second="RiverSolver"/>
-      <max-time-windows value="{{N}}" />
-      <time-window-size value="{{dt}}" />
-      <exchange data="Flux" mesh="RiverMesh" from="GroundwaterSolver" to="RiverSolver"/>
-      <exchange data="Height" mesh="RiverMesh" from="RiverSolver" to="GroundwaterSolver" initialize="yes"/>
-      {%- if "implicit" in coupling_scheme %}
-      <absolute-convergence-measure limit="{{tolerance}}" data="Height" mesh="RiverMesh"/>
-      <absolute-convergence-measure limit="{{tolerance}}" data="Flux" mesh="RiverMesh" />
-      <min-iteration-convergence-measure min-iterations="{{min_iterations}}" data="Height" mesh="RiverMesh"/>
-      <max-iterations value="{{max_iterations}}" />
-      <acceleration:constant>
-        <relaxation value="{{omega}}" />
-      </acceleration:constant>
-      {%- endif %}
-    </coupling-scheme:{{coupling_scheme}}>
-
-  </solver-interface>
+  <coupling-scheme:{{coupling_scheme}}>
+    <participants first="GroundwaterSolver" second="RiverSolver"/>
+    <max-time-windows value="{{N}}" />
+    <time-window-size value="{{dt}}" />
+    <exchange data="Flux" mesh="RiverMesh" from="GroundwaterSolver" to="RiverSolver"/>
+    <exchange data="Height" mesh="RiverMesh" from="RiverSolver" to="GroundwaterSolver" initialize="yes"/>
+    {%- if "implicit" in coupling_scheme %}
+    <absolute-convergence-measure limit="{{tolerance}}" data="Height" mesh="RiverMesh"/>
+    <absolute-convergence-measure limit="{{tolerance}}" data="Flux" mesh="RiverMesh" />
+    <min-iterations value="{{min_iterations}}"/>
+    <max-iterations value="{{max_iterations}}" />
+    <acceleration:constant>
+      <relaxation value="{{omega}}" />
+    </acceleration:constant>
+    {%- endif %}
+  </coupling-scheme:{{coupling_scheme}}>
 
 </precice-configuration>

--- a/coupling/river.py
+++ b/coupling/river.py
@@ -65,12 +65,18 @@ def simulate_river(params: Params):
     while participant.is_coupling_ongoing():
         if participant.requires_writing_checkpoint():
             river.save_state()
+
+        t = river.time
         precice_dt = participant.get_max_time_step_size()
         dt = min(params.dt, precice_dt)
 
-        flux = participant.read_data(mesh_name, read_data_name)
+        read_data = participant.read_data(mesh_name, read_data_name, vertex_ids, t + dt)
+        flux = read_data[0]
+
         river.solve(dt, flux)
-        participant.write_data(mesh_name, write_data_name, vertex_ids, [river.height])
+
+        write_data = [river.height]
+        participant.write_data(mesh_name, write_data_name, vertex_ids, write_data)
 
         participant.advance(dt)
 

--- a/coupling/river.py
+++ b/coupling/river.py
@@ -39,7 +39,7 @@ def simulate_river(params: Params):
     participant_name = "RiverSolver"
     solver_process_index = 0
     solver_process_size = 1
-    interface = precice.Interface(
+    participant = precice.Participant(
         participant_name,
         str(params.precice_config),
         solver_process_index,
@@ -47,41 +47,37 @@ def simulate_river(params: Params):
     )
 
     mesh_name = "RiverMesh"
-    mesh_id = interface.get_mesh_id(mesh_name)
-    dimensions = interface.get_dimensions()
+    dimensions = participant.get_mesh_dimensions(mesh_name)
     vertex = np.zeros(dimensions)
-    vertex_id = interface.set_mesh_vertex(mesh_id, vertex)
 
-    height_id = interface.get_data_id("Height", mesh_id)
-    flux_id = interface.get_data_id("Flux", mesh_id)
+    vertex_ids = [participant.set_mesh_vertex(mesh_name, vertex)]
+
+    read_data_name = "Flux"
+    write_data_name = "Height"
 
     river = River(params)
 
-    precice_dt = interface.initialize()
+    if participant.requires_initial_data():
+        participant.write_data(mesh_name, write_data_name, vertex_ids, [params.h_0])
 
-    if interface.is_action_required(precice.action_write_initial_data()):
-        interface.write_scalar_data(height_id, vertex_id, params.h_0)
-        interface.mark_action_fulfilled(precice.action_write_initial_data())
+    participant.initialize()
 
-    interface.initialize_data()
-
-    while interface.is_coupling_ongoing():
-        if interface.is_action_required(precice.action_write_iteration_checkpoint()):
+    while participant.is_coupling_ongoing():
+        if participant.requires_writing_checkpoint():
             river.save_state()
-            interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
+        precice_dt = participant.get_max_time_step_size()
         dt = min(params.dt, precice_dt)
 
-        flux = interface.read_scalar_data(flux_id, vertex_id)
+        flux = participant.read_data(mesh_name, read_data_name)
         river.solve(dt, flux)
-        interface.write_scalar_data(height_id, vertex_id, river.height)
+        participant.write_data(mesh_name, write_data_name, vertex_ids, [river.height])
 
-        precice_dt = interface.advance(dt)
+        participant.advance(dt)
 
-        if interface.is_action_required(precice.action_read_iteration_checkpoint()):
+        if participant.requires_reading_checkpoint():
             river.load_state()
-            interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
         else:
             river.end_time_step()
 
-    interface.finalize()
+    participant.finalize()
     river.save_output("river.nc")


### PR DESCRIPTION
Updates to preCICE API calls + XML according to their [porting guide](https://precice.org/couple-your-code-porting-v2-3.html) + using Benjamin's [oscillator code](https://github.com/BenjaminRodenberg/oscillator-example/tree/main/precice-3).

Two other updates:
- switch from `dune.fem.uflFunction` to `dune.fem.gridFunction` (due to `DeprecationWarning`)
- support linearly varying hydraulic capacity `c`